### PR TITLE
Issue 1 Fix: Add setup.py/pypi support for the cp4pc project in its current form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
-
+# Ignore python leftovers
 *.pyc
+*.pyo
+
+# Ignore trash left behind by editors
+*~
+\#*\#
+
+# Ignore setuptools trash
+dist
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,36 @@
+from setuptools import setup
+
+
+setup(
+    name='cp4pc',
+    version='0.1',
+    author='Multiple Contributors',
+    author_email='osbpau@gmail.com',  # should be email of pypi package maintainer
+    description=(
+        "A set of libraries designed to make a PC development environment "
+        "look similar to the environment present on Digi's Connectport gateway "
+        "products."),
+    long_description=open('README.txt').read(),
+    packages=[
+        'rci',
+    ],
+    py_modules=[
+        'addp',
+        'cwm',
+        'digicli',
+        'idigidata',
+        'simulator_settings',
+        'xbee',
+        'zigbee',
+    ],
+    # don't include webob, just mark as dependency
+    install_requires=[
+        'webob==1.2b3',
+    ],
+    license="MPL 2.0",
+    url="https://github.com/jordanh/cp4pc",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+    ],
+)


### PR DESCRIPTION
This was tested against the recently launched pypi test server at
http://testpypi.python.org/pypi/cp4pc/0.1.  I have not released the
package to the main pypi at this point in time (questions related to
release schedule and package maintainer apply).
